### PR TITLE
Add commented Kotzilla coordinates to libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ koin = "4.2.0-RC1"
 koin-plugin = "0.3.0"
 agp = "8.13.2"
 compose-multiplatform = "1.9.3"
+# Kotzilla observability (optional) — sends sessions to https://console.kotzilla.io
+# kotzilla = "2.1.3"
 
 [libraries]
 # Core Koin
@@ -28,6 +30,9 @@ koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", ver
 koin-compose-viewmodel-navigation = { module = "io.insert-koin:koin-compose-viewmodel-navigation", version.ref = "koin" }
 koin-androidx-compose = { module = "io.insert-koin:koin-androidx-compose", version.ref = "koin" }
 
+# For compose app only - not needed for other app:
+# kotzilla-sdk-compose = { group = "io.kotzilla", name = "kotzilla-sdk-compose", version.ref = "kotzilla" }
+
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
@@ -38,3 +43,5 @@ koin = { id = "io.insert-koin.compiler.plugin", version.ref = "koin-plugin" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
+# Kotzilla Gradle plugin — convenient way to wire up the SDK setup
+# kotzilla = { id = "io.kotzilla.kotzilla-plugin", version.ref = "kotzilla" }


### PR DESCRIPTION
## Summary
- Adds optional Kotzilla observability entries (version, compose SDK library, Gradle plugin) to the centralized `gradle/libs.versions.toml`
- All Kotzilla entries are commented out — developers uncomment when ready to wire up the SDK
- Console URL (`https://console.kotzilla.io`) included in the SDK version comment, per spec

Resolves [KTZ-4022](https://linear.app/kotzilla/issue/KTZ-4022/update-libsversionstoml-in-koin-getting-started).

## Test plan
- [ ] Confirm `./gradlew help` still resolves the catalog with no parse errors
- [ ] Uncomment the three Kotzilla entries locally and verify `kotzilla-sdk-compose` resolves from Maven Central in the `compose/` project

🤖 Generated with [Claude Code](https://claude.com/claude-code)