### PR TITLE
KTZ-4015 Add "Going further" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ tools. One data layer, four surfaces:
   exploration of that data: timelines, distributions, app-vitals
   dashboards.
 - **Kotzilla MCP Server** — same data in the terminal, exposed
-  to Claude Code / Cursor or other AI agents for in-flow diagnosis, fixes, and build
-  reports.
+  to Claude Code / Cursor or other AI agents for SDK setup
+  guidance, in-flow diagnosis, fixes, and build reports.
 - **Koin IDE Plugin** ("Koin Dependency Injection (Official)"
   on JetBrains Marketplace) — Koin configuration viz, Insights
   View, and AI-powered fix prompts in Android Studio / IntelliJ.

--- a/README.md
+++ b/README.md
@@ -40,5 +40,25 @@ Additional readings about basic setup: https://github.com/InsertKoinIO/koin/blob
 
 Support this project by becoming a sponsor. Your logo will show up here with a link to your website. [[Become a sponsor](https://opencollective.com/koin#sponsor)]
 
+## Going further
 
+This sample uses Koin's core APIs only. For production work, the
+team behind Koin (Kotzilla) maintains four official, complementary
+tools. One data layer, four surfaces:
 
+- **Kotzilla SDK** — captures the data the Console and the MCP
+  Server read. Drop in via `monitoring()` below; coordinates in
+  `libs.versions.toml`.
+- **Kotzilla Console** (https://console.kotzilla.io/?utm_source=koin-getting-started&utm_medium=readme&utm_campaign=awareness) — visual
+  exploration of that data: timelines, distributions, app-vitals
+  dashboards.
+- **Kotzilla MCP Server** — same data in the terminal, exposed
+  to Claude Code / Cursor or other AI agents for in-flow diagnosis, fixes, and build
+  reports.
+- **Koin IDE Plugin** ("Koin Dependency Injection (Official)"
+  on JetBrains Marketplace) — Koin configuration viz, Insights
+  View, and AI-powered fix prompts in Android Studio / IntelliJ.
+  Requires Kotzilla account sign-in.
+
+Reference integration: https://github.com/kotzilla-io/kmp-app-monitoring
+Setup details: docs/observability.md


### PR DESCRIPTION
## Summary

Appends a `## Going further` section at the end of `README.md` introducing the four official Kotzilla pieces (SDK, Console, MCP Server, IDE Plugin) in role order, with the one-data-layer-four-surfaces framing. Closes with a pointer to `https://github.com/kotzilla-io/kmp-app-monitoring` (reference integration) and to `docs/observability.md` for setup details.

Content is Snippet E from the Notion source, verbatim (including the UTM-instrumented Console link).

## Why

Surfaces the official Koin ecosystem at the README touchpoint without pushing it — anyone evaluating Koin via this template sees the production-grade tooling exists. Part of the P0 "koin-getting-started baseline" workstream.

Ticket: [KTZ-4015](https://linear.app/kotzilla/issue/KTZ-4015/add-going-further-section-to-readme)

## Test plan

- [ ] Render the README on GitHub — verify the new section renders correctly, all links resolve, and nothing in the existing content was perturbed.
- [ ] Confirm `https://github.com/kotzilla-io/kmp-app-monitoring` is in a presentable state (the ticket flags this as a reviewer check).
- [ ] Confirm `docs/observability.md` exists on `main` once [PR #10](https://github.com/InsertKoinIO/koin-getting-started/pull/10) (KTZ-4012) merges — this PR's `Setup details:` link depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)