### PR TITLE
KTZ-4014 Add // monitoring() comment line in startKoin / install(Koin) blocks

### DIFF
--- a/android-annotations/app/src/main/kotlin/org/koin/sample/MainApplication.kt
+++ b/android-annotations/app/src/main/kotlin/org/koin/sample/MainApplication.kt
@@ -8,6 +8,7 @@ import org.koin.core.annotation.KoinViewModelScopeApi
 import org.koin.core.logger.Level
 import org.koin.core.option.viewModelScopeFactory
 import org.koin.plugin.module.dsl.startKoin
+// import io.kotzilla.generated.monitoring
 
 /**
  * Main Application class for the Koin Annotations sample app.
@@ -33,6 +34,7 @@ class MainApplication : Application() {
             androidContext(this@MainApplication)
             androidLogger(level = Level.DEBUG)
             options(viewModelScopeFactory())
+            // monitoring()  // optional — Kotzilla observability, see docs/observability.md
         }
     }
 }

--- a/android-compose/app/src/main/kotlin/org/koin/sample/MainApplication.kt
+++ b/android-compose/app/src/main/kotlin/org/koin/sample/MainApplication.kt
@@ -3,6 +3,7 @@ package org.koin.sample
 import android.app.Application
 import org.koin.core.context.startKoin
 import org.koin.sample.di.appModule
+// import io.kotzilla.generated.monitoring
 
 class MainApplication : Application() {
 
@@ -12,6 +13,7 @@ class MainApplication : Application() {
 
         startKoin {
             modules(appModule)
+            // monitoring()  // optional — Kotzilla observability, see docs/observability.md
         }
     }
 }

--- a/android/app/src/main/kotlin/org/koin/sample/MainApplication.kt
+++ b/android/app/src/main/kotlin/org/koin/sample/MainApplication.kt
@@ -6,6 +6,7 @@ import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
 import org.koin.core.logger.Level
 import org.koin.sample.di.appModule
+// import io.kotzilla.generated.monitoring
 
 /**
  * Application class that initializes Koin dependency injection framework.
@@ -32,6 +33,7 @@ class MainApplication : Application() {
             androidLogger(Level.DEBUG)
             androidContext(this@MainApplication)
             modules(appModule)
+            // monitoring()  // optional — Kotzilla observability, see docs/observability.md
         }
     }
 }

--- a/compose/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/di/Koin.kt
+++ b/compose/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/di/Koin.kt
@@ -26,6 +26,7 @@ import org.koin.mp.KoinPlatform
 import org.koin.plugin.module.dsl.create
 import org.koin.plugin.module.dsl.single
 import org.koin.plugin.module.dsl.viewModel
+// import io.kotzilla.generated.monitoring
 
 interface PlatformComponent {
     fun getInfo(): String
@@ -68,6 +69,7 @@ fun initKoin(configuration: KoinAppDeclaration? = null) {
         includes(configuration)
         modules(appModule)
         printLogger(Level.DEBUG)
+        // monitoring()  // optional — Kotzilla observability, see docs/observability.md
     }
 
     val nativeComponent = KoinPlatform.getKoin().get<NativeComponent>().getInfo()

--- a/kotlin-annotations/app/src/main/kotlin/org/koin/sample/UserApplication.kt
+++ b/kotlin-annotations/app/src/main/kotlin/org/koin/sample/UserApplication.kt
@@ -6,6 +6,7 @@ import org.koin.core.context.startKoin
 import org.koin.mp.KoinPlatform
 import org.koin.plugin.module.dsl.startKoin
 import org.koin.sample.service.UserService
+// import io.kotzilla.generated.monitoring
 
 /**
  * Main application class that demonstrates Koin dependency injection.
@@ -62,7 +63,9 @@ object KoinUserApplication
  * to demonstrate the dependency injection in action.
  */
 fun main() {
-    startKoin<KoinUserApplication>()
+    startKoin<KoinUserApplication> {
+        // monitoring()  // optional — Kotzilla observability, see docs/observability.md
+    }
 
     val userApplication = KoinPlatform.getKoin().get<UserApplication>()
     userApplication.sayHello("Alice")

--- a/kotlin/app/src/main/kotlin/org/koin/sample/UserApplication.kt
+++ b/kotlin/app/src/main/kotlin/org/koin/sample/UserApplication.kt
@@ -4,6 +4,7 @@ import org.koin.core.context.startKoin
 import org.koin.mp.KoinPlatform
 import org.koin.sample.di.appModule
 import org.koin.sample.service.UserService
+// import io.kotzilla.generated.monitoring
 
 /**
  * Main application class that demonstrates Koin dependency injection.
@@ -50,6 +51,7 @@ class UserApplication(
 fun main() {
     startKoin {
         modules(appModule)
+        // monitoring()  // optional — Kotzilla observability, see docs/observability.md
     }
 
     val userApplication = KoinPlatform.getKoin().get<UserApplication>()

--- a/ktor-annotations/app/src/main/kotlin/org/koin/sample/KoinUserApplication.kt
+++ b/ktor-annotations/app/src/main/kotlin/org/koin/sample/KoinUserApplication.kt
@@ -11,6 +11,7 @@ import org.koin.ktor.plugin.Koin
 import org.koin.logger.slf4jLogger
 import org.koin.plugin.module.dsl.withConfiguration
 import org.koin.sample.service.UserService
+// import io.kotzilla.generated.monitoring
 
 /**
  * Koin application configuration object.
@@ -52,6 +53,7 @@ fun Application.main() {
     install(Koin){
         slf4jLogger()
         withConfiguration<KoinUserApplication>()
+        // monitoring()  // optional — Kotzilla observability, see docs/observability.md
     }
 
     // Inject UserService and initialize with default users

--- a/ktor/app/src/main/kotlin/org/koin/sample/UserApplication.kt
+++ b/ktor/app/src/main/kotlin/org/koin/sample/UserApplication.kt
@@ -10,6 +10,7 @@ import org.koin.ktor.plugin.Koin
 import org.koin.logger.slf4jLogger
 import org.koin.sample.di.appModule
 import org.koin.sample.service.UserService
+// import io.kotzilla.generated.monitoring
 
 /**
  * Application entry point that starts the Ktor server.
@@ -38,6 +39,7 @@ fun Application.main() {
     // Configure Koin dependency injection
     install(Koin) {
         modules(appModule)
+        // monitoring()  // optional — Kotzilla observability, see docs/observability.md
     }
 
     // Inject UserService and initialize with default users


### PR DESCRIPTION
## Summary

For every sample's Koin activation site, drops a commented `monitoring()` call (pointing to `docs/observability.md`) plus a commented `io.kotzilla.generated.monitoring` import. A developer who wants to enable Kotzilla observability uncomments the two lines and adds the SDK coordinates from `libs.versions.toml` — nothing else needed.

Content is Snippet F from the Notion source.

## Files touched (8)

- `startKoin { … }` blocks: `android/`, `android-compose/`, `kotlin/`, `compose/`, `android-annotations/`
- `kotlin-annotations/`: the bare `startKoin<KoinUserApplication>()` call is converted to a block-form call so the comment has a home — same semantics, generated function accepts an optional block.
- `install(Koin) { … }` blocks: `ktor/`, `ktor-annotations/` — extended beyond the literal "startKoin" wording. `install(Koin)` is the equivalent activation pattern on Ktor and instrumenting it keeps the awareness story consistent across all sample variants. Happy to drop these two files from the PR if you'd prefer to stay strictly within "startKoin".

## Why

Surfaces the Kotzilla SDK at the natural touchpoint — the Koin activation block every developer has to look at when wiring DI. The framing (`// optional — Kotzilla observability, see docs/observability.md`) makes the call discoverable without pushing it. Part of the P0 "koin-getting-started baseline" workstream.

Ticket: [KTZ-4014](https://linear.app/kotzilla/issue/KTZ-4014/add-monitoring-comment-line-in-startkoin-blocks-across-samples)

## Deviations from Snippet F to flag

- **Import is commented out.** Snippet F shows `import io.kotzilla.generated.monitoring` uncommented. The Kotzilla SDK is not on the classpath of these samples (per the matching `libs.versions.toml` ticket KTZ-4022 / Snippet B convention, the coordinates stay commented until a developer opts in), so leaving the import uncommented would fail to compile. Commenting it preserves the snippet's intent (show the developer what they'd need) without breaking the build.
- **`compose-annotations/` skipped.** The `initKoin` function in `compose-annotations/composeApp/src/commonMain/kotlin/com/jetbrains/kmpapp/di/Koin.kt` is already fully commented out — no live call site to instrument. Worth a follow-up: once that function is restored, it'll need the same treatment.
- **Test code untouched.** `kotlin-annotations/.../HelloMockTest.kt` has a `startKoin<KoinUserApplication>()` call too, but Snippet F targets sample apps and `monitoring()` doesn't belong in tests.
- **Existing `analytics()` calls on Android left alone.** Per Snippet F's explicit rule — both forms are valid; don't auto-rewrite. (No Android sample in this repo currently uses `analytics()`, so this is just a confirmation of intent, not a behavioural change.)

## Test plan

- [ ] `./gradlew build` (or per-sample equivalents) on each of the 8 sample folders — confirm nothing broke. The changes are pure additions of commented lines plus one `()` → `{ … }` rewrite in `kotlin-annotations`.
- [ ] Spot-check that each commented `monitoring()` line lands inside the right Koin activation block (not in a sibling block or scope).
- [ ] Confirm the scope-call on `ktor` / `ktor-annotations` is acceptable, or drop those two files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)