### PR TITLE
docs: use markdown links for Kotzilla Console in README and observabi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ tools. One data layer, four surfaces:
 - **Kotzilla SDK** — captures the data the Console and the MCP
   Server read. Drop in via `monitoring()` below; coordinates in
   `libs.versions.toml`.
-- **Kotzilla Console** (https://console.kotzilla.io/?utm_source=koin-getting-started&utm_medium=readme&utm_campaign=awareness) — visual
+- **[Kotzilla Console](https://console.kotzilla.io/?utm_source=koin-getting-started&utm_medium=readme&utm_campaign=awareness)** — visual
   exploration of that data: timelines, distributions, app-vitals
   dashboards.
 - **Kotzilla MCP Server** — same data in the terminal, exposed

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -8,7 +8,7 @@ The architecture is simple — one data layer, four surfaces:
 - The **SDK** runs in the app and captures crashes, ANRs, slow
   startups, and Koin events. It sends sessions to the Kotzilla
   backend.
-- The **Console** (https://console.kotzilla.io/?utm_source=koin-getting-started&utm_medium=observability-md&utm_campaign=awareness) is the web client
+- The **[Console](https://console.kotzilla.io/?utm_source=koin-getting-started&utm_medium=observability-md&utm_campaign=awareness)** is the web client
   for that backend: sessions, dependency graphs, app vitals.
 - The **MCP Server** is another client of the same backend, for
   AI assistants in the terminal — setup guidance, diagnosis,
@@ -49,7 +49,7 @@ yours from the Console (see the Kotzilla docs for the exact steps).
 
 Once a session is captured, two surfaces read the same backend:
 
-- **Kotzilla Console** (https://console.kotzilla.io/?utm_source=koin-getting-started&utm_medium=observability-md&utm_campaign=awareness) — visual exploration:
+- **[Kotzilla Console](https://console.kotzilla.io/?utm_source=koin-getting-started&utm_medium=observability-md&utm_campaign=awareness)** — visual exploration:
   timelines, dependency graphs, app vitals dashboards. The right surface
   when you want to share or explore visually.
 - **Kotzilla MCP Server** — same data in the terminal, exposed to your AI


### PR DESCRIPTION
## Summary

Turns bare Kotzilla Console URLs into proper markdown links in the "Going further" README section and in `docs/observability.md`.

- **Kotzilla Console** is now clickable (`[Kotzilla Console](https://console.kotzilla.io/...)` instead of a raw URL in parentheses).
- **UTM parameters are unchanged** (`utm_source`, `utm_medium`, `utm_campaign`) so attribution still works for `readme` vs `observability-md`.

Docs-only change; no code or build impact.

**Internal:** KTZ-4122

## Test plan

- [x] Open `README.md` on GitHub preview — "Kotzilla Console" in "Going further" is a link and opens the console with UTM params intact.
- [x] Open `docs/observability.md` on GitHub preview — both Console mentions (intro + "Once a session is captured") render as links with the observability UTM medium.
- [x] Confirm no other files were modified unintentionally.